### PR TITLE
Append share=1 to existing path args

### DIFF
--- a/QuoraLoginBypass.user.js
+++ b/QuoraLoginBypass.user.js
@@ -30,9 +30,14 @@ for (let i = 0, constLen = whitelistURL.length ; i < constLen ; i++) {
         }
     }
 }
-if (changeURL == false || url.indexOf("?share=1") != -1) {
+if (changeURL == false || url.indexOf("share=1") != -1) {
     return false
 } else {
-    url += "?share=1";
+    if (url.indexOf("?") != -1) {
+        url += "&share=1";
+    } else {
+        url += "?share=1";
+    }
+
     window.location.replace(url)
 }


### PR DESCRIPTION
Some links on the Quora website end with `?no_redirect=1` (eg. open [What is the importance of baking?](https://www.quora.com/What-is-the-importance-of-baking) and then click on the "[Related] What is the significance of baking in daily life?" link).

This lead to weird behavior where `?share=1` was still added to the URL, creating a URL ending with `?no_redirect=1?share=1`, which is invalid syntax and Firefox doesn't parse the intended `share=1` argument correctly and the website requested a login. URL args should be concatenated with `&`, not `?`.

Sometimes the `?share=1` was added URL-encoded, meaning `%3Fshare%3D1` was actually added, so the check on line 33 (`url.indexOf("?share=1") != -1`) returned false and the `?share=1` string was being added to the URL repeatedly causing periodic reloading of the page with a URL like `?no_redirect=1%3Fshare%3D1%3Fshare%3D1%3Fshare%3D1%3Fshare%3D1%3Fshare%3D1`. This should be fixed too.